### PR TITLE
Changes for the alert message or pop-up message when order fetching

### DIFF
--- a/Controller/TicketExtension.php
+++ b/Controller/TicketExtension.php
@@ -69,7 +69,7 @@ class TicketExtension
                 'success' => true,
                 'orderDetails' => $eCommerceOrderDetails,
                 'alertClass' => 'success',
-                'alertMessage' => 'Success! Order updated successfully.',
+                'alertMessage' => 'Success! Order Added to the ticket.',
                 'collectedOrders' => $params['orderId'],
             ];
         } else {


### PR DESCRIPTION
**Changes for the alert message or pop-up message when order fetching**

**Showing this pop-up message: "Success! Order updated successfully."** instead of this message: **"Success! Order Added to the ticket."**

**Issue No: https://github.com/uvdesk/ecommerce/issues/8** 